### PR TITLE
Fix ImportError(s) for binary entry point using relative imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,37 @@
 # Update the code and upload the package to pypi
-# 1. python ./setup.py sdist --format=gztar
-# 2. twine upload dist/simple_tensorflow_serving-1.0.0.tar.gz
+# 1. python ./setup.py bdist_wheel --universal
+# 2. twine upload dist/simple_tensorflow_serving-0.4.x-py2.py3-none-any.whl
 
-try:
-  from setuptools import setup
-  setup()
-except ImportError:
-  from distutils.core import setup
+from setuptools import setup, find_packages
 
 setup(
     name="simple_tensorflow_serving",
-    version="0.4.1",
+    version="0.4.7",
     author="tobe",
     author_email="tobeg3oogle@gmail.com",
     url="https://github.com/tobegit3hub/simple_tensorflow_serving",
-    #install_requires=["tensorflow>=1.0.0"],
     description=
     "The simpler and easy-to-use serving service for TensorFlow models",
-    packages=[
-        "simple_tensorflow_serving", "simple_tensorflow_serving.gen_client"
+    packages=find_packages(),
+    install_requires=[
+        'pandas',
+        'numpy',
+        'flask',
+        'jinja2',
+        'pillow',
+        'flask-cors',
+        'requests',
+        'pyarrow',
+        'tensorflow',
+        'scikit-learn',
+        'xgboost',
+        'mxnet',
+        'h2o',
+        'onnx',
     ],
     #package_data={
-    #    "simple_tensorflow_serving/static": ['simple_tensorflow_serving/templates/*.html', 'simple_tensorflow_serving/static/*']
+    #    "simple_tensorflow_serving/static": ['simple_tensorflow_serving/templates/*.html',
+    #                                         'simple_tensorflow_serving/static/*']
     #},
     include_package_data=True,
     zip_safe=False,

--- a/simple_tensorflow_serving/h2o_inference_service.py
+++ b/simple_tensorflow_serving/h2o_inference_service.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 from collections import namedtuple
 
-from abstract_inference_service import AbstractInferenceService
+from .abstract_inference_service import AbstractInferenceService
 
 
 class H2oInferenceService(AbstractInferenceService):

--- a/simple_tensorflow_serving/mxnet_inference_service.py
+++ b/simple_tensorflow_serving/mxnet_inference_service.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 from collections import namedtuple
 
-from abstract_inference_service import AbstractInferenceService
+from .abstract_inference_service import AbstractInferenceService
 
 
 class MxnetInferenceService(AbstractInferenceService):

--- a/simple_tensorflow_serving/onnx_inference_service.py
+++ b/simple_tensorflow_serving/onnx_inference_service.py
@@ -10,7 +10,7 @@ import json
 import numpy as np
 from collections import namedtuple
 
-from abstract_inference_service import AbstractInferenceService
+from .abstract_inference_service import AbstractInferenceService
 
 
 class OnnxInferenceService(AbstractInferenceService):

--- a/simple_tensorflow_serving/scikitlearn_inference_service.py
+++ b/simple_tensorflow_serving/scikitlearn_inference_service.py
@@ -7,7 +7,7 @@ import time
 import numpy as np
 import pickle
 
-from abstract_inference_service import AbstractInferenceService
+from .abstract_inference_service import AbstractInferenceService
 
 
 class ScikitlearnInferenceService(AbstractInferenceService):

--- a/simple_tensorflow_serving/server.py
+++ b/simple_tensorflow_serving/server.py
@@ -15,15 +15,15 @@ import numpy as np
 from flask import Flask, Response, jsonify, render_template, request
 from flask_cors import CORS
 
-from tensorflow_inference_service import TensorFlowInferenceService
-from gen_client import gen_client
-from mxnet_inference_service import MxnetInferenceService
-from onnx_inference_service import OnnxInferenceService
-from h2o_inference_service import H2oInferenceService
-from scikitlearn_inference_service import ScikitlearnInferenceService
-from xgboost_inference_service import XgboostInferenceService
-from service_utils import request_util
-import python_predict_client
+from .tensorflow_inference_service import TensorFlowInferenceService
+from .gen_client import gen_client
+from .mxnet_inference_service import MxnetInferenceService
+from .onnx_inference_service import OnnxInferenceService
+from .h2o_inference_service import H2oInferenceService
+from .scikitlearn_inference_service import ScikitlearnInferenceService
+from .xgboost_inference_service import XgboostInferenceService
+from .service_utils import request_util
+from . import python_predict_client
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -254,7 +254,7 @@ if args.gen_client != "":
 if args.reload_models == "True" or args.reload_models == "true":
   for model_name, inference_service in model_name_service_map.items():
     if inference_service.platform == "tensorflow":
-      inference_service.dynmaically_reload_models()
+      inference_service.dynamically_reload_models()
 
 
 # The API to render the dashboard page

--- a/simple_tensorflow_serving/templates/index.html
+++ b/simple_tensorflow_serving/templates/index.html
@@ -44,7 +44,7 @@
             <tbody>
 
 
-            {% for model_name, inference_service in model_name_service_map.iteritems() %}
+            {% for model_name, inference_service in model_name_service_map.items() %}
                 {% for model_version in inference_service.model_version_list %}
                     <tr>
                         <td class="text-center">{{ model_name }}</td>
@@ -76,7 +76,7 @@
     <h4>Graph Signature</h4>
 
     <ul class="nav nav-pills mb-3">
-        {% for model_name, inference_service in model_name_service_map.iteritems() %}
+        {% for model_name, inference_service in model_name_service_map.items() %}
 
             <!-- Make the first item active -->
             {% if loop.index0 == 0 %}
@@ -91,7 +91,7 @@
     </ul>
 
     <div class="tab-content ">
-        {% for model_name, inference_service in model_name_service_map.iteritems() %}
+        {% for model_name, inference_service in model_name_service_map.items() %}
 
             <!-- Make the first item active -->
             {% if loop.index0 == 0 %}

--- a/simple_tensorflow_serving/tensorflow_inference_service.py
+++ b/simple_tensorflow_serving/tensorflow_inference_service.py
@@ -14,7 +14,7 @@ import subprocess
 
 import tensorflow as tf
 
-from abstract_inference_service import AbstractInferenceService
+from .abstract_inference_service import AbstractInferenceService
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -85,7 +85,7 @@ class TensorFlowInferenceService(AbstractInferenceService):
       else:
         logging.error("The path does not exist: {}".format(custom_op_path))
 
-  def dynmaically_reload_models(self):
+  def dynamically_reload_models(self):
     """
     Start new thread to load models periodically.
 

--- a/simple_tensorflow_serving/xgboost_inference_service.py
+++ b/simple_tensorflow_serving/xgboost_inference_service.py
@@ -7,7 +7,7 @@ import time
 import numpy as np
 import pickle
 
-from abstract_inference_service import AbstractInferenceService
+from .abstract_inference_service import AbstractInferenceService
 
 
 class XgboostInferenceService(AbstractInferenceService):


### PR DESCRIPTION
Additional changes:
- Change 'iteritems' -> 'items' to support dashboard on Py3
- Suggestion: Remove distutils.core support and use wheel packaging instead
I'll leave the versioning to you. I just put 0.4.7 because I saw 0.4.6 on PyPI

Both `python setup.py install` 
and building the wheel like  `python ./setup.py bdist_wheel --universal && pip install dist/simple_tensorflow_serving-0.4.7-py2.py3-none-any.whl` seem to be working

I tested this on
MacOS - Py 3.6
Ubuntu Linux 14.04 - Py 2.7
