### PR TITLE
Fix for #39 and #40

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
     install_requires=[
         'pandas',
         'numpy',
+        'protobuf',
+        'onnx',
         'flask',
         'jinja2',
         'flask-cors',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'jinja2',
         'flask-cors',
         'requests',
+        'pillow',
         'tensorflow'
     ],
     #package_data={

--- a/simple_tensorflow_serving/pytorch_onnx_inference_service.py
+++ b/simple_tensorflow_serving/pytorch_onnx_inference_service.py
@@ -11,7 +11,7 @@ import json
 import numpy as np
 from collections import namedtuple
 
-from abstract_inference_service import AbstractInferenceService
+from .abstract_inference_service import AbstractInferenceService
 
 
 # Lazy init


### PR DESCRIPTION
For #39, it appears that the issue was caused by the lines
```python
from __future__ import absolute_import
```
then 
```python
from abstract_inference_service import AbstractInferenceService
```
The new absolute import does not allow importing sibling files without explicitly specifying the path (i.e. `from .abstract_inference_service import AbstractInferenceService`)


For #40, added `pillow` as one of the dependencies during installation.
