### PR TITLE
Fix TemplateNotFound (#60)

### DIFF
--- a/simple_tensorflow_serving/server.py
+++ b/simple_tensorflow_serving/server.py
@@ -142,7 +142,11 @@ class WsgiApp:
 
   def __init__(self, args):
     self.args = args
-    self.app = Flask("simple_tensorlow_serving", template_folder='templates')
+    self.app = Flask(
+      "simple_tensorlow_serving",
+      template_folder="simple_tensorflow_serving/templates",
+      static_folder="simple_tensorflow_serving/static",
+    )
     self.manager = InferenceServiceManager(args)
 
     # Initialize Flask app with parameters


### PR DESCRIPTION
Modifying `template_folder` and passing `static_folder` explicitly fixes the [TemplateNotFound: index.html (#60)](https://github.com/tobegit3hub/simple_tensorflow_serving/issues/60) issue.