### PR TITLE
Open binary files in binary mode

### DIFF
--- a/simple_tensorflow_serving/preprocess_util.py
+++ b/simple_tensorflow_serving/preprocess_util.py
@@ -10,14 +10,14 @@ import logging
 logger = logging.getLogger("simple_tensorflow_serving")
 
 
-def get_functrion_from_marshal_file(function_file_path,
+def get_function_from_marshal_file(function_file_path,
                                     function_name="function"):
   logging.info("Try to get function from file: {}".format(function_file_path))
 
   function_object = None
 
   if os.path.exists(function_file_path):
-    with open(function_file_path, "r") as f:
+    with open(function_file_path, "rb") as f:
       preprocess_function_string = f.read()
       loaded_function = marshal.loads(preprocess_function_string)
       function_object = types.FunctionType(loaded_function,
@@ -32,10 +32,10 @@ def get_preprocess_postprocess_function_from_model_path(model_base_path):
 
   preprocess_file_path = os.path.join(model_parent_path,
                                       "preprocess_function.marshal")
-  preprocess_function = get_functrion_from_marshal_file(preprocess_file_path)
+  preprocess_function = get_function_from_marshal_file(preprocess_file_path)
 
   postprocess_file_path = os.path.join(model_parent_path,
                                        "postprocess_function.marshal")
-  postprocess_function = get_functrion_from_marshal_file(postprocess_file_path)
+  postprocess_function = get_function_from_marshal_file(postprocess_file_path)
 
   return preprocess_function, postprocess_function

--- a/simple_tensorflow_serving/scikitlearn_inference_service.py
+++ b/simple_tensorflow_serving/scikitlearn_inference_service.py
@@ -53,7 +53,7 @@ class ScikitlearnInferenceService(AbstractInferenceService):
       self.pipeline = joblib.load(self.model_base_path)
     elif self.model_base_path.endswith(
         ".pkl") or self.model_base_path.endswith(".pickle"):
-      with open(self.model_base_path, 'r') as f:
+      with open(self.model_base_path, 'rb') as f:
         self.pipeline = pickle.load(f)
     else:
       logger.error(

--- a/simple_tensorflow_serving/xgboost_inference_service.py
+++ b/simple_tensorflow_serving/xgboost_inference_service.py
@@ -55,7 +55,7 @@ class XgboostInferenceService(AbstractInferenceService):
       self.bst = joblib.load(self.model_base_path)
     elif self.model_base_path.endswith(
         ".pkl") or self.model_base_path.endswith(".pickle"):
-      with open(self.model_base_path, 'r') as f:
+      with open(self.model_base_path, 'rb') as f:
         self.bst = pickle.load(f)
     elif self.model_base_path.endswith(
         ".bst") or self.model_base_path.endswith(".bin"):


### PR DESCRIPTION
* Pickled models and marshalled functions must be loaded in binary mode. In python 3, binary flag must be explicitly included in open call.
* Typo fix